### PR TITLE
Fix for bug in RSS when image from imageset displays negative width, height 

### DIFF
--- a/hst/src/main/java/org/bloomreach/forge/feed/api/transform/rss/HippoGalleryImageSetToImageTransformer.java
+++ b/hst/src/main/java/org/bloomreach/forge/feed/api/transform/rss/HippoGalleryImageSetToImageTransformer.java
@@ -33,7 +33,9 @@ public class HippoGalleryImageSetToImageTransformer {
         final String imageLink = hstLinkCreator.create(imageSet, context).toUrlForm(context, true);
         image.setUrl(imageLink);
         image.setLink(baseLink);
-        image.setTitle(imageSet.getFileName());
+        image.setTitle(imageSet.getDescription());
+        image.setHeight(imageSet.getOriginal().getHeight());
+        image.setWidth(imageSet.getOriginal().getWidth());
         return image;
     }
 


### PR DESCRIPTION
image width and height are required and don't validate because set by default to -1 and not set to the right value with the hst/src/main/java/org/bloomreach/forge/feed/api/transform/rss/HippoGalleryImageSetToImageTransformer.java

Another thing is, that the image title should be editable, so I changed the title from file name to image description which can be edited in the CMS gallery. 