### PR TITLE
chore(feed): FORGE-598 Upgrade feeds plugin and demo to BrXM v17

### DIFF
--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>feedsdemo-cms-dependencies</artifactId>
   <packaging>pom</packaging>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>feedsdemo-cms</artifactId>
   <packaging>war</packaging>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>feedsdemo-essentials</artifactId>
   <packaging>war</packaging>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,14 +5,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>feedsdemo</name>
   <description>feedsdemo</description>
   <groupId>org.example</groupId>
   <artifactId>feedsdemo</artifactId>
-  <version>8.0.1-SNAPSHOT</version>
+  <version>9.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--
@@ -63,7 +63,7 @@
     <!--***START temporary override of versions*** -->
     <!-- ***END temporary override of versions*** -->
 
-    <essentials.version>16.0.0</essentials.version>
+    <essentials.version>17.0.0</essentials.version>
     
     <development-module-deploy-dir>shared/lib</development-module-deploy-dir>
 
@@ -75,12 +75,12 @@
     <repository>
       <id>hippo</id>
       <name>Hippo maven 2 repository.</name>
-      <url>https://maven.onehippo.com/maven2/</url>
+      <url>https://maven.bloomreach.com/maven2/</url>
     </repository>
     <repository>
       <id>hippo-forge</id>
       <name>Bloomreach Forge Maven 2 repository.</name>
-      <url>https://maven.onehippo.com/maven2-forge/</url>
+      <url>https://maven.bloomreach.com/maven2-forge/</url>
     </repository>
   </repositories>
 

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-repository-data</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>feedsdemo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-repository-data</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>feedsdemo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>feedsdemo Repository Data</name>

--- a/demo/repository-data/site-development/pom.xml
+++ b/demo/repository-data/site-development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-repository-data</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>feedsdemo Repository Data For Site Development</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-repository-data</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>feedsdemo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-repository-data</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>feedsdemo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-site</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>feedsdemo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>feedsdemo-site</artifactId>
   <packaging>pom</packaging>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.example</groupId>
     <artifactId>feedsdemo-site</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>feedsdemo-webapp</artifactId>
   <packaging>war</packaging>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.example</groupId>
       <artifactId>feedsdemo-components</artifactId>
-      <version>8.0.1-SNAPSHOT</version>
+      <version>9.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/hst/pom.xml
+++ b/hst/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2009-2022 Bloomreach
+    Copyright 2009-2026 Bloomreach
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.bloomreach.forge.feed</groupId>
     <artifactId>feed</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Forge Feed Creator HST Module</name>

--- a/hst/src/main/java/org/bloomreach/forge/feed/resource/AtomSyndicationResource.java
+++ b/hst/src/main/java/org/bloomreach/forge/feed/resource/AtomSyndicationResource.java
@@ -18,7 +18,6 @@ package org.bloomreach.forge.feed.resource;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-;
 
 import com.rometools.rome.feed.atom.Entry;
 import com.rometools.rome.feed.atom.Feed;

--- a/hst/src/main/java/org/bloomreach/forge/feed/util/ConversionUtil.java
+++ b/hst/src/main/java/org/bloomreach/forge/feed/util/ConversionUtil.java
@@ -129,7 +129,7 @@ public class ConversionUtil {
                         }
 
                     }
-                    if (value != null) {
+                    if (value != null && !(value instanceof String && ((String) value).isBlank())) {
                         BeanUtils.setProperty(destination, name, value);
                     }
                 } catch (Exception e) {

--- a/hst/src/test/java/org/bloomreach/forge/feed/RssAtomGenerationTest.java
+++ b/hst/src/test/java/org/bloomreach/forge/feed/RssAtomGenerationTest.java
@@ -42,9 +42,13 @@ import org.slf4j.LoggerFactory;
 
 import com.rometools.rome.feed.atom.Feed;
 import com.rometools.rome.feed.rss.Channel;
+import com.rometools.rome.feed.rss.Item;
 import com.rometools.rome.feed.synd.SyndFeedImpl;
 import com.rometools.rome.io.SyndFeedOutput;
 import com.rometools.rome.io.WireFeedOutput;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 
 public class RssAtomGenerationTest {
 
@@ -97,6 +101,29 @@ public class RssAtomGenerationTest {
     }
 
 
+    @Test
+    public void testBlankStringPropertySkipped() throws Exception {
+        Item item = convertObject(new Item(), new TestBeanWithBlankSource(), FeedType.RSS);
+        // blank source must be silently skipped — Item.source is a complex type, not a String
+        assertNull(item.getSource());
+        // other fields must still be mapped correctly
+        assertEquals("testtitle", item.getTitle());
+    }
+
+    public static class TestBeanWithBlankSource {
+
+        @SyndicationElement(type = FeedType.RSS, name = "title")
+        public String getTitle() {
+            return "testtitle";
+        }
+
+        // mirrors NewsDocument.getSource() returning an empty JCR property
+        @SyndicationElement(type = FeedType.RSS, name = "source")
+        public String getSource() {
+            return "";
+        }
+    }
+
     public static class TestBean {
 
         @SyndicationRefs({
@@ -143,7 +170,7 @@ public class RssAtomGenerationTest {
                 final String name = annotation.name();
                 try {
                     final Object initValue = method.invoke(source);
-                    Object value = null;
+                    Object value = initValue;
                     if (!(annotation.converter().isAssignableFrom(NoopConverter.class))) {
                         final Converter converter = annotation.converter().newInstance();
                         value = converter.convert(initValue);
@@ -183,7 +210,9 @@ public class RssAtomGenerationTest {
                         }
 
                     }
-                    BeanUtils.setProperty(destination, name, value);
+                    if (value != null && !(value instanceof String && ((String) value).isBlank())) {
+                        BeanUtils.setProperty(destination, name, value);
+                    }
                 } catch (Exception e) {
                     log.error("test", e);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright 2009-2024 Bloomreach
+    Copyright 2009-2026 Bloomreach
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.0.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Bloomreach Forge Feed Creator</name>
   <groupId>org.bloomreach.forge.feed</groupId>
   <artifactId>feed</artifactId>
-  <version>8.0.1-SNAPSHOT</version>
+  <version>9.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -71,7 +71,7 @@
 
   <issueManagement>
     <system>Jira</system>
-    <url>https://issues.onehippo.com/browse/HIPFORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <licenses>
@@ -107,7 +107,7 @@
     <repository>
       <id>bloomreach</id>
       <name>Bloomreach Maven 2 repository</name>
-      <url>http://maven.bloomreach.com/maven2/</url>
+      <url>https://maven.bloomreach.com/maven2/</url>
       <snapshots />
       <releases>
         <updatePolicy>never</updatePolicy>
@@ -157,7 +157,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkMode>always</forkMode>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
           <workingDirectory>${project.build.directory}</workingDirectory>
         </configuration>
       </plugin>
@@ -181,10 +182,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven.plugin.javadoc.version}</version>
         <configuration>
-          <source>1.8</source>
-          <links>
-            <link>http://download.oracle.com/javase/6/docs/api</link>
-          </links>
+          <source>21</source>
         </configuration>
       </plugin>
       <plugin>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright 2009-2022 Bloomreach
+    Copyright 2009-2026 Bloomreach
 
     Licensed under the Apache License, Version 2.0 (the  "License");
     you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.bloomreach.forge.feed</groupId>
     <artifactId>feed</artifactId>
-    <version>8.0.1-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Bloomreach Forge Feed Creator Repository Module</name>


### PR DESCRIPTION
Bumps parent BOM from hippo-cms7-project/release 16.0.0 to 17.0.0, targeting JDK 21 and Spring Boot 4. Project version advances from 8.0.1-SNAPSHOT to 9.0.0-SNAPSHOT per Forge release conventions.

Also fixes a pre-existing silent ERROR per RSS item caused by BeanUtils attempting to coerce an empty String to a complex ROME Source type; blank strings are now skipped alongside nulls in ConversionUtil.

Additional housekeeping: HTTPS Maven repo URLs, updated issue tracker URL to bloomreach.atlassian.net, javadoc source level 21, forkMode deprecation resolved, stray semicolon in AtomSyndicationResource removed.

(co-authored with Claude Code)